### PR TITLE
[Draft] make_cake 함수를 호출하는 과정에서 CakeComponent 를 이용한 적절한 추상화 시도

### DIFF
--- a/solving/abstraction_parkchansoo.py
+++ b/solving/abstraction_parkchansoo.py
@@ -1,50 +1,97 @@
+import abc
+import enum
+
+
+class NotValidComponentError(Exception):
+    pass
+
+
+class CakeComponent(enum.Enum):
+    @classmethod
+    @abc.abstractmethod
+    def from_prompt(self, prompt):
+        pass
+
+    @classmethod
+    def handle_prompt(cls, prompt=None, default=None):
+        if prompt is None:
+            return default
+        try:
+            return cls.from_prompt(prompt)
+        except KeyError:
+            raise NotValidComponentError(f"{prompt}은 유효한 값이 아닙니다.")            
+
+
+class Bread(CakeComponent):
+    sponge = "스폰지 케이스 베이스"
+    chocolate = "초콜릿 케이스 베이스"
+    normal = "일반 케이스 베이스"
+
+    @classmethod
+    def from_prompt(cls, prompt):
+        return {
+            "스폰지": cls.sponge,
+            "초콜릿": cls.chocolate,
+            "일반": cls.normal
+        }[prompt]
+
+class Cream(CakeComponent):
+    vanilla = "바닐라 크림"
+    chocolate = "초콜릿 크림"
+    normal = "일반 크림"
+
+    @classmethod
+    def from_prompt(cls, prompt):
+        return {
+            "바닐라": cls.vanilla,
+            "초콜릿": cls.chocolate,
+            "일반": cls.normal
+        }[prompt]
+
+
+class Decoration(CakeComponent):
+    chocolate = "초콜릿 장식"
+    fruit = "과일 장식"
+    normal = "일반 장식"
+
+    @classmethod
+    def from_prompt(cls, prompt):
+        return {
+            "초콜릿": cls.chocolate,
+            "과일": cls.fruit,
+            "일반": cls.normal
+        }[prompt]
+
+
 class Cake:
-    def __init__(self):
-        self.base = ""
-        self.cream = ""
-        self.decoration = ""
-        self.cake_description = []
+    base = Bread.sponge
+    cream = Cream.vanilla
+    decoration = Decoration.chocolate
+    
+    def make_cake(self, base_type=None, cream_type=None, decoration_type=None):
+        try:
+            self.base = Bread.handle_prompt(base_type, self.base)
+            self.cream = Cream.handle_prompt(cream_type, self.cream)
+            self.decoration = Decoration.handle_prompt(decoration_type, self.decoration)
+        except NotValidComponentError as e:
+            print("케이크를 만들 수 없습니다:", e)
+        return self.get_description()
 
-    def prepare_base(self, base_type="스폰지"):
-        if base_type == "스폰지":
-            self.base = "스폰지 케이크 베이스"
-        elif base_type == "초콜릿":
-            self.base = "초콜릿 케이크 베이스"
-        else:
-            self.base = "일반 케이크 베이스"
-        self.cake_description.append(f"{self.base} 준비")
-
-    def add_cream(self, cream_type="바닐라"):
-        if cream_type == "바닐라":
-            self.cream = "바닐라 크림"
-        elif cream_type == "초콜릿":
-            self.cream = "초콜릿 크림"
-        else:
-            self.cream = "일반 크림"
-        self.cake_description.append(f"{self.cream} 추가")
-
-    def decorate(self, decoration_type="초콜릿"):
-        if decoration_type == "초콜릿":
-            self.decoration = "초콜릿 장식"
-        elif decoration_type == "과일":
-            self.decoration = "과일 장식"
-        else:
-            self.decoration = "일반 장식"
-        self.cake_description.append(f"{self.decoration} 추가")
-
-    def make_cake(self, base_type="스폰지", cream_type="바닐라", decoration_type="초콜릿"):
-        self.prepare_base(base_type)
-        self.add_cream(cream_type)
-        self.decorate(decoration_type)
-        self.cake_description.append("케이크가 완성되었습니다!")
-        return "\n".join(self.cake_description)
+    def get_description(self):
+        return "\n".join([
+            self.base.value,
+            self.cream.value,
+            self.decoration.value,
+            "케이크가 완성되었습니다!"
+        ])
+    
 
 
-# 클라이언트 코드
-cake = Cake()
-print(cake.make_cake())
+if __name__ == "__main__":
+    cake = Cake()
+    print(cake.make_cake())
 
-print("\n다른 종류의 케이크 만들기:")
+    print("\n다른 종류의 케이크 만들기:")
 
-another_cake = Cake()
-print(another_cake.make_cake("초콜릿", "초콜릿", "과일"))
+    another_cake = Cake()
+    print(another_cake.make_cake("초콜릿", "초콜릿", "과일"))


### PR DESCRIPTION
# 목적
* 기존의 Cake class 가 구현된 방식에서 유지보수 및 code literacy 를 위한 리팩토링 시도

# 수정 내용
1. base, cream, decoration 을 각각의 enum 형태의 class 로 따로 분리했습니다
    * 추후에 해당 각각의 컴포넌트 별로 user input, 카테고리, 그리고 출력값이 달라지더라도 각각의 클래스만 수정 가능하도록 만드는게 목표입니다 
2. description attribute 를 제거하고 설명문을 생성하는 로직을 따로 함수로 분리했습니다.

# 고민
* 현재 모든 케잌 컴포넌트(빵, 케잌, 데코)가 동등한 구성요소로 보고 구현했으나, 만일 각각의 구성요소 별로 특별한 처리가 필요하다면 enum 구조의 데이터 클래스와 method 구현부를 분리하면 좋을것 같습니다
* 현재 케잌 구성 요소들이 출력되는 방식이 이름 + suffix (예: `장식`, `케이크 베이스`) 와 같이 정해진 규칙이 있는데 해당 규칙은 언제든 바뀔 수 있을거라 가정하고 각각을 따로 literal 로 작성했습니다. 만일 항상 rule base 로 되는거라면 해당 함수를 따로 만드는게 좋을것 같습니다