### PR TITLE
[5주차 과제] -  식단추가 함수 리팩토링 

### DIFF
--- a/sangwoo/addMeals_problemSolving.java
+++ b/sangwoo/addMeals_problemSolving.java
@@ -49,14 +49,8 @@ protected boolean HashMap addMeals(HashMap orderMap) throws Exception{
                  * qty가 4인 경우가 생겼을때 itemCnt ArrayIndexOutOfBoundsException 발생
                  */
                 if(mealItemList.size() > 0){
-                    int itemCnt[] = {0,1,2};
+                    int itemCnt[] = setMealItemTypeIdx();
                     String odOrderDetlGrpId ="";
-                    if(mealItemList.size() == 1){
-                        itemCnt[1] = 0;
-                        itemCnt[2] = 0;
-                    } else if(mealItemList.size() == 2){
-                        itemCnt[2] = 1;
-                    }
                     for(int k=0; k<qty; k++){
                         //OD_ORDER_DETL GRP_ID 생성
                         if(k ==0){
@@ -78,4 +72,15 @@ protected boolean HashMap addMeals(HashMap orderMap) throws Exception{
     
     
     
+    }
+
+    private int[] setMealItemTypeIdx(){
+        int itemCnt[] = {0,1,2};
+        if(mealItemList.size() == 1){
+            itemCnt[1] = 0;
+            itemCnt[2] = 0;
+        } else if(mealItemList.size() == 2){
+            itemCnt[2] = 1;
+        }
+        return itemCnt;
     }

--- a/sangwoo/addMeals_problemSolving.java
+++ b/sangwoo/addMeals_problemSolving.java
@@ -49,18 +49,18 @@ protected boolean HashMap addMeals(HashMap orderMap) throws Exception{
                  * qty가 4인 경우가 생겼을때 itemCnt ArrayIndexOutOfBoundsException 발생
                  */
                 if(mealItemList.size() > 0){
-                    int itemCnt[] = setMealItemTypeIdx();
+                    int itemTypeIdx[] = setMealItemTypeIdx(qty, mealItemList.size());
                     String odOrderDetlGrpId ="";
                     for(int k=0; k<qty; k++){
                         //OD_ORDER_DETL GRP_ID 생성
                         if(k ==0){
                             odOrderDetlGrpId = (String)dao.selectOne("subscribeOrderCreate.getOdOrderDetlGrpId");
                         }
-                        else if(itemCnt[k-1] != itemCnt[k]){
+                        else if(itemTypeIdx[k-1] != itemTypeIdx[k]){
                             odOrderDetlGrpId = (String)dao.selectOne("subscribeOrderCreate.getOdOrderDetlGrpId");
                         }
                         HashMap mealItem = new HashMap();
-                        mealItem.putAll(mealItemList.get(itemCnt[k]));
+                        mealItem.putAll(mealItemList.get(itemTypeIdx[k]));
                        //... 
                     }
                 }
@@ -74,13 +74,22 @@ protected boolean HashMap addMeals(HashMap orderMap) throws Exception{
     
     }
 
-    private int[] setMealItemTypeIdx(){
-        int itemCnt[] = {0,1,2};
-        if(mealItemList.size() == 1){
-            itemCnt[1] = 0;
-            itemCnt[2] = 0;
-        } else if(mealItemList.size() == 2){
-            itemCnt[2] = 1;
+//구독주문상품조회 mealList
+//구독주문마켓상품조회, 구독주문식단상품조회 mealItemList 뭔차이?
+//qty는 배송되어야하는 상품 개수, mealItemList.size()는 상품이 몇 종류인지
+//mealItemList.size()는 qty보다 클일이 거의 없다
+private int[] setMealItemTypeIdx(int qty, int mealItemListSize){
+    int[] mealItemTypeIdx = new int[qty];
+    for(int i=0; i<qty; i++) mealItemTypeIdx[i] = i;
+
+    try{
+         if(qty > mealItemListSize){
+             for(int i=mealItemListSize; i<mealItemTypeIdx.size(); i++){
+                  qty[i]=mealItemListSize-1;
+            }
         }
-        return itemCnt;
-    }
+      } catch(ArrayIndexOutOfBoundsException e){
+           e.printStackTrace();
+      }
+      return mealItemTypeIdx;
+}

--- a/sangwoo/addMeals_problemSolving.java
+++ b/sangwoo/addMeals_problemSolving.java
@@ -84,7 +84,7 @@ private int[] setMealItemTypeIdx(int qty, int mealItemListSize){
 
     try{
          if(qty > mealItemListSize){
-             for(int i=mealItemListSize; i<mealItemTypeIdx.size(); i++){
+             for(int i=mealItemListSize; i<qty; i++){
                   qty[i]=mealItemListSize-1;
             }
         }


### PR DESCRIPTION
# 문제정의
* 기존의 식단추가 함수에서 식단의 개수가 3개 미만 -> 4개인 상황이 추가됐을때 오류 발생

# 사전지식
```
qty = 상품 개수
mealItemListSize = 상품 종류 개수
```

```
qty < mealItemListSize(상품 종류 개수가 상품 개수보다 많은 경우)는 없음
qty = mealItemListSize(상품 종류 개수와 상품 개수가 같은 경우)까지만 존재
```

# 리팩토링 목표
식단 추가 로직은 길고 복잡하므로 모든 것을 고치기는 불가능
도메인 로직 숙지가 완벽하지도 않고, 잘 돌아가는 거를 건들 수는 없기 때문
  
* 상품 개수가 증가했을때 문제가 발생한 부분만 수정하기
* 상품 개수에 상관없이 분기처리를 하지 않아도 잘 동작하는 코드로 수정하기


# 수정 내용
* 식단타입 설정 부분 함수화
* 배열 할당 정적할당 -> 동적할당
식단의 개수와 상관없이 잘 동작하게 확장성 개선
* 배열의 이름 명시적으로 수정


# 아쉬웠던 점
* 내가 함수로 만든 부분도 코드만 보면 무슨 동작을 하는지 명확히 이해하기가 어려움
* 이전 코드나 이후 코드를 보지 않으면 이해 불가능
그런데 이거를 개선하려면 문제가 되는 부분 뿐만 아니라 잘 되는 부분도 가독성을 위해 수정해야함
* 그러면 걷잡을 수 없이 큰 작업이 되기 때문에 이 부분이 조금 아쉬웠지만
그래도 원래 목표는 달성해서 좋았다

 